### PR TITLE
Add /quitquitquit endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -417,6 +418,12 @@ func countWorkersByState(stats locustStats, state string) float64 {
 	return float64(count)
 }
 
+type quitHandler struct{}
+
+func (h quitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	os.Exit(0)
+}
+
 func main() {
 
 	var (
@@ -442,6 +449,7 @@ func main() {
 	prometheus.MustRegister(version.NewCollector("locustexporter"))
 
 	http.Handle(*metricsPath, promhttp.Handler())
+	http.Handle("/quitquitquit", quitHandler{})
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`<html><head><title>Locust Exporter</title></head><body><h1>Locust Exporter</h1><p><a href='` + *metricsPath + `'>Metrics</a></p></body></html>`))
 	})

--- a/main.go
+++ b/main.go
@@ -418,12 +418,6 @@ func countWorkersByState(stats locustStats, state string) float64 {
 	return float64(count)
 }
 
-type quitHandler struct{}
-
-func (h quitHandler) ServeHTTP(http.ResponseWriter, *http.Request) {
-	os.Exit(0)
-}
-
 func main() {
 
 	var (
@@ -449,7 +443,7 @@ func main() {
 	prometheus.MustRegister(version.NewCollector("locustexporter"))
 
 	http.Handle(*metricsPath, promhttp.Handler())
-	http.Handle("/quitquitquit", quitHandler{})
+	http.HandleFunc("/quitquitquit", func(http.ResponseWriter, *http.Request) { os.Exit(0) })
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`<html><head><title>Locust Exporter</title></head><body><h1>Locust Exporter</h1><p><a href='` + *metricsPath + `'>Metrics</a></p></body></html>`))
 	})

--- a/main.go
+++ b/main.go
@@ -420,7 +420,7 @@ func countWorkersByState(stats locustStats, state string) float64 {
 
 type quitHandler struct{}
 
-func (h quitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h quitHandler) ServeHTTP(http.ResponseWriter, *http.Request) {
 	os.Exit(0)
 }
 


### PR DESCRIPTION
Adds an endpoint to kill the application. This way the exporter can also be used in a (cron-)job, by having Locust call this endpoint before terminating itself.

Suggested in https://github.com/ContainerSolutions/locust_exporter/issues/35

Probably need to add this to the documentation (and changelog?).