### PR TITLE
Fix percentile response time and add per-endpoint 90th and 99th percentile response time

### DIFF
--- a/main.go
+++ b/main.go
@@ -313,8 +313,8 @@ type locustStats struct {
 	} `json:"errors"`
 	TotalRps                                 float64 `json:"total_rps"`
 	FailRatio                                float64 `json:"fail_ratio"`
-	CurrentResponseTimePercentileNinetyFifth float64 `json:"current_response_time_percentile_95"`
-	CurrentResponseTimePercentileFiftieth    float64 `json:"current_response_time_percentile_50"`
+	CurrentResponseTimePercentileNinetyFifth float64 `json:"current_response_time_percentile_2"`
+	CurrentResponseTimePercentileFiftieth    float64 `json:"current_response_time_percentile_1"`
 	WorkerCount                              int     `json:"worker_count,omitempty"`
 	State                                    string  `json:"state"`
 	UserCount                                int     `json:"user_count"`


### PR DESCRIPTION
Previously, the percentile response times were not properly collected. Running some experiments, seems that scrape method do not parse properly json fields obtained from `./stats/requests` locust endpoint.

## Changes

This PR will: 
1. Fix overall 50th percentile response time collection
2. Add two per-endpoint metrics (GaugeVec) that collect 95th and 99th response-time